### PR TITLE
Add zenity as recommended dependency

### DIFF
--- a/spotify-client.spec
+++ b/spotify-client.spec
@@ -32,6 +32,7 @@ Requires:       libopenssl1_0_0
 Requires:       libpng12-0
 Recommends:     libmp3lame0
 Recommends:     ffmpeg
+Recommends:     zenity
 %endif
 
 # not currently tested on Fedora or Mandriva, but leaving


### PR DESCRIPTION
Without it you get `sh: zenity: command not found` when clicking on Settings -> Local Files -> ADD A SOURCE